### PR TITLE
Shorten the help to 80 characters

### DIFF
--- a/commands/certs/chain.js
+++ b/commands/certs/chain.js
@@ -21,7 +21,7 @@ function * run (context) {
 module.exports = {
   topic: '_certs',
   command: 'chain',
-  description: 'print the ordered and complete chain for the given certificate',
+  description: 'print an ordered & complete chain for a certificate',
   needsApp: true,
   needsAuth: true,
   variableArgs: true,

--- a/commands/certs/generate.js
+++ b/commands/certs/generate.js
@@ -157,7 +157,7 @@ module.exports = {
       description: 'do not prompt for any owner information'
     }
   ],
-  description: 'generate a key and certificate signing request (or self-signed certificate)',
+  description: 'generate a key and a CSR or self-signed certificate',
   help: 'Generate a key and certificate signing request (or self-signed certificate)\nfor an app. Prompts for information to put in the certificate unless --now\nis used, or at least one of the --subject, --owner, --country, --area, or\n--city options is specified.',
   needsApp: true,
   needsAuth: true,


### PR DESCRIPTION
@dickeyxxx review me to make sure I did not mangle the language ?
```
-> % heroku plugins:link . ; heroku help _certs
Symlinking heroku-certs... done
Usage: heroku _certs

List SSL certificates for an app.

 -a, --app APP       # app to run command against
 -r, --remote REMOTE # git remote of app to run command against

Additional commands, type "heroku help COMMAND" for more details:

  _certs:add CRT KEY      #  add an SSL certificate to an app
  _certs:chain            #  print an ordered & complete chain for a certificate
  _certs:generate DOMAIN  #  generate a key and a CSR or self-signed certificate
  _certs:info             #  show certificate information for an SSL certificate
  _certs:key              #  print the correct key for the given certificate
  _certs:remove           #  remove an SSL certificate from an app
  _certs:rollback         #  rollback an SSL certificate from an app
  _certs:update CRT KEY   #  update an SSL certificate on an app
```