### PR TITLE
Rename _certs to certs & hide _certs

### DIFF
--- a/commands/certs/add.js
+++ b/commands/certs/add.js
@@ -264,8 +264,7 @@ function * run (context, heroku) {
   displayWarnings(cert)
 }
 
-module.exports = {
-  topic: '_certs',
+let cmd = {
   command: 'add',
   args: [
     {name: 'CRT', optional: false},
@@ -279,9 +278,14 @@ module.exports = {
   description: 'add an SSL certificate to an app',
   help: `Example:
 
- $ heroku _certs:add example.com.crt example.com.key
+ $ heroku certs:add example.com.crt example.com.key
 `,
   needsApp: true,
   needsAuth: true,
   run: cli.command(co.wrap(run))
 }
+
+module.exports = [
+  Object.assign({topic: 'certs'}, cmd),
+  Object.assign({topic: '_certs', hidden: true}, cmd)
+]

--- a/commands/certs/chain.js
+++ b/commands/certs/chain.js
@@ -18,8 +18,7 @@ function * run (context) {
   cli.console.writeLog(body)
 }
 
-module.exports = {
-  topic: '_certs',
+let cmd = {
   command: 'chain',
   description: 'print an ordered & complete chain for a certificate',
   needsApp: true,
@@ -27,3 +26,9 @@ module.exports = {
   variableArgs: true,
   run: cli.command(co.wrap(run))
 }
+
+module.exports = [
+  Object.assign({topic: 'certs'}, cmd),
+  Object.assign({topic: '_certs', hidden: true}, cmd)
+]
+

--- a/commands/certs/generate.js
+++ b/commands/certs/generate.js
@@ -95,7 +95,7 @@ function * run (context, heroku) {
 
     cli.console.error('Your key and self-signed certificate have been generated.')
     cli.console.error('Next, run:')
-    cli.console.error(`$ heroku _certs:${command} ${crtfile} ${keyfile}`)
+    cli.console.error(`$ heroku certs:${command} ${crtfile} ${keyfile}`)
   } else {
     let csrfile = `${domain}.csr`
 
@@ -104,12 +104,11 @@ function * run (context, heroku) {
     cli.console.error('Your key and certificate signing request have been generated.')
     cli.console.error(`Submit the CSR in '${csrfile}' to your preferred certificate authority.`)
     cli.console.error("When you've received your certificate, run:")
-    cli.console.error(`$ heroku _certs:${command} CERTFILE ${keyfile}`)
+    cli.console.error(`$ heroku certs:${command} CERTFILE ${keyfile}`)
   }
 }
 
-module.exports = {
-  topic: '_certs',
+let cmd = {
   command: 'generate',
   args: [
     {name: 'domain', optional: false}
@@ -162,9 +161,14 @@ module.exports = {
 
 Example:
 
- $ heroku _certs:generate example.com
+ $ heroku certs:generate example.com
 `,
   needsApp: true,
   needsAuth: true,
   run: cli.command(co.wrap(run))
 }
+
+module.exports = [
+  Object.assign({topic: 'certs'}, cmd),
+  Object.assign({topic: '_certs', hidden: true}, cmd)
+]

--- a/commands/certs/index.js
+++ b/commands/certs/index.js
@@ -10,16 +10,20 @@ function * run (context, heroku) {
   let certsAndDomains = yield endpoints(context.app, heroku)
 
   if (certsAndDomains.certs.length === 0) {
-    cli.log(`${cli.color.app(context.app)} has no SSL certificates.\nUse ${cli.color.cmd('heroku _certs:add CRT KEY')} to add one.`)
+    cli.log(`${cli.color.app(context.app)} has no SSL certificates.\nUse ${cli.color.cmd('heroku certs:add CRT KEY')} to add one.`)
   } else {
     displayTable(certsAndDomains.certs, certsAndDomains.domains)
   }
 }
 
-module.exports = {
-  topic: '_certs',
+let cmd = {
   description: 'List SSL certificates for an app.',
   needsApp: true,
   needsAuth: true,
   run: cli.command(co.wrap(run))
 }
+
+module.exports = [
+  Object.assign({topic: 'certs'}, cmd),
+  Object.assign({topic: '_certs', hidden: true}, cmd)
+]

--- a/commands/certs/info.js
+++ b/commands/certs/info.js
@@ -17,8 +17,7 @@ function * run (context, heroku) {
   certificateDetails(cert)
 }
 
-module.exports = {
-  topic: '_certs',
+let cmd = {
   command: 'info',
   flags: [
     {name: 'name', hasValue: true, description: 'name to check info on'},
@@ -29,3 +28,8 @@ module.exports = {
   needsAuth: true,
   run: cli.command(co.wrap(run))
 }
+
+module.exports = [
+  Object.assign({topic: 'certs'}, cmd),
+  Object.assign({topic: '_certs', hidden: true}, cmd)
+]

--- a/commands/certs/key.js
+++ b/commands/certs/key.js
@@ -9,7 +9,7 @@ let sslDoctor = require('../../lib/ssl_doctor.js')
 
 function * run (context) {
   if (context.args.length < 2) {
-    error.exit(1, 'Usage: heroku _certs:key CRT KEY [KEY ...]\nMust specify one certificate file and at least one key file.')
+    error.exit(1, 'Usage: heroku certs:key CRT KEY [KEY ...]\nMust specify one certificate file and at least one key file.')
   }
 
   let res = yield context.args.map(function (arg) { return readFile(arg) })
@@ -18,18 +18,22 @@ function * run (context) {
   cli.console.writeLog(body.key)
 }
 
-module.exports = {
-  topic: '_certs',
+let cmd = {
   command: 'key',
   description: 'print the correct key for the given certificate',
   help: `You must pass one single certificate, and one or more keys.\nThe first key that signs the certificate will be printed back.
 
 Example:
 
- $ heroku _certs:key example.com.crt example.com.key
+ $ heroku certs:key example.com.crt example.com.key
 `,
   needsApp: true,
   needsAuth: true,
   variableArgs: true,
   run: cli.command(co.wrap(run))
 }
+
+module.exports = [
+  Object.assign({topic: 'certs'}, cmd),
+  Object.assign({topic: '_certs', hidden: true}, cmd)
+]

--- a/commands/certs/remove.js
+++ b/commands/certs/remove.js
@@ -27,8 +27,7 @@ function * run (context, heroku) {
   }
 }
 
-module.exports = {
-  topic: '_certs',
+let cmd = {
   command: 'remove',
   flags: [
     {name: 'confirm', hasValue: true, hidden: true},
@@ -40,3 +39,8 @@ module.exports = {
   needsAuth: true,
   run: cli.command(co.wrap(run))
 }
+
+module.exports = [
+  Object.assign({topic: 'certs'}, cmd),
+  Object.assign({topic: '_certs', hidden: true}, cmd)
+]

--- a/commands/certs/rollback.js
+++ b/commands/certs/rollback.js
@@ -26,8 +26,7 @@ function * run (context, heroku) {
   certificateDetails(cert, 'New active certificate details:')
 }
 
-module.exports = {
-  topic: '_certs',
+let cmd = {
   command: 'rollback',
   flags: [
     {name: 'confirm', hasValue: true, optional: true, hidden: true},
@@ -39,3 +38,9 @@ module.exports = {
   needsAuth: true,
   run: cli.command(co.wrap(run))
 }
+
+module.exports = [
+  Object.assign({topic: 'certs'}, cmd),
+  Object.assign({topic: '_certs', hidden: true}, cmd)
+]
+

--- a/commands/certs/update.js
+++ b/commands/certs/update.js
@@ -42,8 +42,7 @@ function * run (context, heroku) {
   displayWarnings(cert)
 }
 
-module.exports = {
-  topic: '_certs',
+let cmd = {
   command: 'update',
   args: [
     {name: 'CRT', optional: false},
@@ -64,3 +63,8 @@ module.exports = {
   needsAuth: true,
   run: cli.command(co.wrap(run))
 }
+
+module.exports = [
+  Object.assign({topic: 'certs'}, cmd),
+  Object.assign({topic: '_certs', hidden: true}, cmd)
+]

--- a/index.js
+++ b/index.js
@@ -1,11 +1,14 @@
 'use strict'
+
+let _ = require('lodash')
+
 exports.topic = {
   name: 'heroku',
   // this is the help text that shows up under `heroku help`
   description: 'a topic for the ssl plugin'
 }
 
-exports.commands = [
+exports.commands = _.flatten([
   require('./commands/certs/index.js'),
   require('./commands/certs/add.js'),
   require('./commands/certs/chain.js'),
@@ -15,4 +18,4 @@ exports.commands = [
   require('./commands/certs/remove.js'),
   require('./commands/certs/rollback.js'),
   require('./commands/certs/update.js')
-]
+])

--- a/test/commands/certs/add.js
+++ b/test/commands/certs/add.js
@@ -28,7 +28,7 @@ describe('heroku certs:add', function () {
     error.exit.mock()
 
     inquirer = {}
-    certs = proxyquire('../../../commands/certs/add', {inquirer})
+    certs = proxyquire('../../../commands/certs/add', {inquirer})[0]
   })
 
   describe('(ported)', function () {

--- a/test/commands/certs/chain.js
+++ b/test/commands/certs/chain.js
@@ -6,7 +6,7 @@ let nock = require('nock')
 var fs = require('fs')
 var sinon = require('sinon')
 
-let certs = require('../../../commands/certs/chain.js')
+let certs = require('../../../commands/certs/chain.js')[0]
 let assertExit = require('../../assert_exit.js')
 let error = require('../../../lib/error.js')
 

--- a/test/commands/certs/generate.js
+++ b/test/commands/certs/generate.js
@@ -12,7 +12,7 @@ chai.use(sinonChai)
 let cli = require('heroku-cli-util')
 let childProcess = require('child_process')
 
-let certs = require('../../../commands/certs/generate.js')
+let certs = require('../../../commands/certs/generate.js')[0]
 let endpoint = require('../../stubs/sni-endpoints.js').endpoint
 
 let EventEmitter = require('events').EventEmitter
@@ -113,7 +113,7 @@ describe('heroku certs:generate', function () {
         `Your key and certificate signing request have been generated.
 Submit the CSR in 'example.com.csr' to your preferred certificate authority.
 When you've received your certificate, run:
-$ heroku _certs:add CERTFILE example.com.key
+$ heroku certs:add CERTFILE example.com.key
 `)
 
       expect(childProcess.spawn).to.have.been.calledWith('openssl', ['req', '-new', '-newkey', 'rsa:2048', '-nodes', '-keyout', 'example.com.key', '-out', 'example.com.csr', '-subj', '/CN=example.com'])
@@ -129,7 +129,7 @@ $ heroku _certs:add CERTFILE example.com.key
       expect(cli.stderr).to.equal(
         `Your key and self-signed certificate have been generated.
 Next, run:
-$ heroku _certs:add example.com.crt example.com.key
+$ heroku certs:add example.com.crt example.com.key
 `)
 
       expect(childProcess.spawn).to.have.been.calledWith('openssl', ['req', '-new', '-newkey', 'rsa:2048', '-nodes', '-keyout', 'example.com.key', '-out', 'example.com.crt', '-subj', '/CN=example.com', '-x509'])
@@ -146,7 +146,7 @@ $ heroku _certs:add example.com.crt example.com.key
         `Your key and certificate signing request have been generated.
 Submit the CSR in 'example.org.csr' to your preferred certificate authority.
 When you've received your certificate, run:
-$ heroku _certs:update CERTFILE example.org.key
+$ heroku certs:update CERTFILE example.org.key
 `)
 
       expect(childProcess.spawn).to.have.been.calledWith('openssl', ['req', '-new', '-newkey', 'rsa:2048', '-nodes', '-keyout', 'example.org.key', '-out', 'example.org.csr', '-subj', '/CN=example.org'])
@@ -173,7 +173,7 @@ $ heroku _certs:update CERTFILE example.org.key
         `Your key and certificate signing request have been generated.
 Submit the CSR in 'example.org.csr' to your preferred certificate authority.
 When you've received your certificate, run:
-$ heroku _certs:update CERTFILE example.org.key
+$ heroku certs:update CERTFILE example.org.key
 `)
 
       expect(childProcess.spawn).to.have.been.calledWith('openssl', ['req', '-new', '-newkey', 'rsa:2048', '-nodes', '-keyout', 'example.org.key', '-out', 'example.org.csr', '-subj', '/CN=example.org'])
@@ -190,7 +190,7 @@ $ heroku _certs:update CERTFILE example.org.key
         `Your key and certificate signing request have been generated.
 Submit the CSR in 'example.org.csr' to your preferred certificate authority.
 When you've received your certificate, run:
-$ heroku _certs:update CERTFILE example.org.key
+$ heroku certs:update CERTFILE example.org.key
 `)
 
       expect(childProcess.spawn).to.have.been.calledWith('openssl', ['req', '-new', '-newkey', 'rsa:4096', '-nodes', '-keyout', 'example.org.key', '-out', 'example.org.csr', '-subj', '/CN=example.org'])

--- a/test/commands/certs/index.js
+++ b/test/commands/certs/index.js
@@ -3,7 +3,7 @@
 
 let expect = require('chai').expect
 let nock = require('nock')
-let certs = require('../../../commands/certs/index.js')
+let certs = require('../../../commands/certs/index.js')[0]
 
 let endpoint = require('../../stubs/sni-endpoints.js').endpoint
 let endpoint2 = require('../../stubs/sni-endpoints.js').endpoint2
@@ -64,7 +64,7 @@ akita-7777  akita-7777.herokussl.com  heroku.com      2013-08-01 21:34 UTC  True
         mockSsl.done()
         mockDomains.done()
         expect(cli.stderr).to.equal('')
-        expect(cli.stdout).to.equal(`example has no SSL certificates.\nUse heroku _certs:add CRT KEY to add one.\n`)
+        expect(cli.stdout).to.equal(`example has no SSL certificates.\nUse heroku certs:add CRT KEY to add one.\n`)
       })
     })
   })

--- a/test/commands/certs/info.js
+++ b/test/commands/certs/info.js
@@ -1,7 +1,7 @@
 'use strict'
 /* globals describe it beforeEach cli */
 
-let certs = require('../../../commands/certs/info.js')
+let certs = require('../../../commands/certs/info.js')[0]
 let nock = require('nock')
 let expect = require('chai').expect
 

--- a/test/commands/certs/key.js
+++ b/test/commands/certs/key.js
@@ -6,7 +6,7 @@ let nock = require('nock')
 var fs = require('fs')
 var sinon = require('sinon')
 
-let certs = require('../../../commands/certs/key.js')
+let certs = require('../../../commands/certs/key.js')[0]
 let assertExit = require('../../assert_exit.js')
 let error = require('../../../lib/error.js')
 
@@ -28,7 +28,7 @@ describe('heroku certs:key', function () {
   it('# validates that at least one argument is passed', function () {
     return assertExit(1, certs.run({app: 'example', args: ['foo']})).then(function () {
       expect(cli.stderr).to.equal(
-        ` ▸    Usage: heroku _certs:key CRT KEY [KEY ...]
+        ` ▸    Usage: heroku certs:key CRT KEY [KEY ...]
  ▸    Must specify one certificate file and at least one key file.
 `)
       expect(cli.stdout).to.equal('')

--- a/test/commands/certs/remove.js
+++ b/test/commands/certs/remove.js
@@ -3,7 +3,7 @@
 
 let expect = require('chai').expect
 let nock = require('nock')
-let certs = require('../../../commands/certs/remove.js')
+let certs = require('../../../commands/certs/remove.js')[0]
 let error = require('../../../lib/error.js')
 
 let endpoint = require('../../stubs/sni-endpoints.js').endpoint

--- a/test/commands/certs/rollback.js
+++ b/test/commands/certs/rollback.js
@@ -3,7 +3,7 @@
 
 let expect = require('chai').expect
 let nock = require('nock')
-let certs = require('../../../commands/certs/rollback.js')
+let certs = require('../../../commands/certs/rollback.js')[0]
 let error = require('../../../lib/error.js')
 let assertExit = require('../../assert_exit.js')
 

--- a/test/commands/certs/update.js
+++ b/test/commands/certs/update.js
@@ -6,7 +6,7 @@ let nock = require('nock')
 var fs = require('fs')
 var sinon = require('sinon')
 
-let certs = require('../../../commands/certs/update.js')
+let certs = require('../../../commands/certs/update.js')[0]
 let error = require('../../../lib/error.js')
 let shared = require('./shared.js')
 let sharedSsl = require('./shared_ssl.js')


### PR DESCRIPTION
@brettgoulder @dickeyxxx could you review?  This just drops the underscore from `_certs` but leaves the old commands hidden in case people keep using them after the beta period.  Once this and https://github.com/heroku/heroku-certs/pull/17 have been merged I think we are all set to go for the 22nd in the CLI assuming that API removes the `http-sni` flag check first.