### PR TITLE
Encapsulate the formatting of endpoints & 	Add an deprecation warning

### DIFF
--- a/commands/certs/add.js
+++ b/commands/certs/add.js
@@ -305,7 +305,8 @@ function * run (context, heroku) {
   displayWarnings(cert)
 }
 
-let cmd = {
+module.exports = {
+  topic: 'certs',
   command: 'add',
   args: [
     {name: 'CRT', optional: false},
@@ -325,8 +326,3 @@ let cmd = {
   needsAuth: true,
   run: cli.command(co.wrap(run))
 }
-
-module.exports = [
-  Object.assign({topic: 'certs'}, cmd),
-  Object.assign({topic: '_certs', hidden: true}, cmd)
-]

--- a/commands/certs/chain.js
+++ b/commands/certs/chain.js
@@ -18,7 +18,8 @@ function * run (context) {
   cli.console.writeLog(body)
 }
 
-let cmd = {
+module.exports = {
+  topic: 'certs',
   command: 'chain',
   description: 'print an ordered & complete chain for a certificate',
   needsApp: true,
@@ -26,9 +27,3 @@ let cmd = {
   variableArgs: true,
   run: cli.command(co.wrap(run))
 }
-
-module.exports = [
-  Object.assign({topic: 'certs'}, cmd),
-  Object.assign({topic: '_certs', hidden: true}, cmd)
-]
-

--- a/commands/certs/generate.js
+++ b/commands/certs/generate.js
@@ -108,7 +108,8 @@ function * run (context, heroku) {
   }
 }
 
-let cmd = {
+module.exports = {
+  topic: 'certs',
   command: 'generate',
   args: [
     {name: 'domain', optional: false}
@@ -167,8 +168,3 @@ Example:
   needsAuth: true,
   run: cli.command(co.wrap(run))
 }
-
-module.exports = [
-  Object.assign({topic: 'certs'}, cmd),
-  Object.assign({topic: '_certs', hidden: true}, cmd)
-]

--- a/commands/certs/index.js
+++ b/commands/certs/index.js
@@ -16,14 +16,10 @@ function * run (context, heroku) {
   }
 }
 
-let cmd = {
+module.exports = {
+  topic: 'certs',
   description: 'List SSL certificates for an app.',
   needsApp: true,
   needsAuth: true,
   run: cli.command(co.wrap(run))
 }
-
-module.exports = [
-  Object.assign({topic: 'certs'}, cmd),
-  Object.assign({topic: '_certs', hidden: true}, cmd)
-]

--- a/commands/certs/info.js
+++ b/commands/certs/info.js
@@ -17,7 +17,8 @@ function * run (context, heroku) {
   certificateDetails(cert)
 }
 
-let cmd = {
+module.exports = {
+  topic: 'certs',
   command: 'info',
   flags: [
     {name: 'name', hasValue: true, description: 'name to check info on'},
@@ -28,8 +29,3 @@ let cmd = {
   needsAuth: true,
   run: cli.command(co.wrap(run))
 }
-
-module.exports = [
-  Object.assign({topic: 'certs'}, cmd),
-  Object.assign({topic: '_certs', hidden: true}, cmd)
-]

--- a/commands/certs/key.js
+++ b/commands/certs/key.js
@@ -18,7 +18,8 @@ function * run (context) {
   cli.console.writeLog(body.key)
 }
 
-let cmd = {
+module.exports = {
+  topic: 'certs',
   command: 'key',
   description: 'print the correct key for the given certificate',
   help: `You must pass one single certificate, and one or more keys.\nThe first key that signs the certificate will be printed back.
@@ -32,8 +33,3 @@ Example:
   variableArgs: true,
   run: cli.command(co.wrap(run))
 }
-
-module.exports = [
-  Object.assign({topic: 'certs'}, cmd),
-  Object.assign({topic: '_certs', hidden: true}, cmd)
-]

--- a/commands/certs/remove.js
+++ b/commands/certs/remove.js
@@ -28,7 +28,8 @@ function * run (context, heroku) {
   }
 }
 
-let cmd = {
+module.exports = {
+  topic: 'certs',
   command: 'remove',
   flags: [
     {name: 'confirm', hasValue: true, hidden: true},
@@ -40,8 +41,3 @@ let cmd = {
   needsAuth: true,
   run: cli.command(co.wrap(run))
 }
-
-module.exports = [
-  Object.assign({topic: 'certs'}, cmd),
-  Object.assign({topic: '_certs', hidden: true}, cmd)
-]

--- a/commands/certs/remove.js
+++ b/commands/certs/remove.js
@@ -5,16 +5,17 @@ let cli = require('heroku-cli-util')
 
 let flags = require('../../lib/flags.js')
 let endpoints = require('../../lib/endpoints.js')
+let formatEndpoint = require('../../lib/format_endpoint.js')
 
 function * run (context, heroku) {
   let endpoint = yield flags(context, heroku)
 
-  let cname = endpoint.cname ? `(${endpoint.cname}) ` : ''
+  let formattedEndpoint = formatEndpoint(endpoint)
 
-  yield cli.confirmApp(context.app, context.flags.confirm, `Potentially Destructive Action\nThis command will remove the endpoint ${endpoint.name} ${cname}from ${cli.color.app(context.app)}.`)
+  yield cli.confirmApp(context.app, context.flags.confirm, `Potentially Destructive Action\nThis command will remove the endpoint ${formattedEndpoint} from ${cli.color.app(context.app)}.`)
 
   let actions = yield {
-    action: cli.action(`Removing SSL certificate ${endpoint.name} ${cname}from ${cli.color.app(context.app)}`, {}, heroku.request({
+    action: cli.action(`Removing SSL certificate ${formattedEndpoint} from ${cli.color.app(context.app)}`, {}, heroku.request({
       path: endpoint._meta.path,
       method: 'DELETE',
       headers: {'Accept': `application/vnd.heroku+json; version=3.${endpoint._meta.variant}`}

--- a/commands/certs/rollback.js
+++ b/commands/certs/rollback.js
@@ -6,6 +6,7 @@ let cli = require('heroku-cli-util')
 let flags = require('../../lib/flags.js')
 let error = require('../../lib/error.js')
 let displayWarnings = require('../../lib/display_warnings.js')
+let formatEndpoint = require('../../lib/format_endpoint.js')
 let certificateDetails = require('../../lib/certificate_details.js')
 
 function * run (context, heroku) {
@@ -14,9 +15,11 @@ function * run (context, heroku) {
     error.exit(1, 'SNI Endpoints cannot be rolled back, please update with a new cert.')
   }
 
-  yield cli.confirmApp(context.app, context.flags.confirm, `Potentially Destructive Action\nThis command will change the certificate of endpoint ${endpoint.name} (${endpoint.cname}) from ${cli.color.app(context.app)}.`)
+  let formattedEndpoint = formatEndpoint(endpoint)
 
-  let cert = yield cli.action(`Rolling back SSL certificate ${endpoint.name} (${endpoint.cname}) for ${cli.color.app(context.app)}`, {}, heroku.request({
+  yield cli.confirmApp(context.app, context.flags.confirm, `Potentially Destructive Action\nThis command will change the certificate of endpoint ${formattedEndpoint} from ${cli.color.app(context.app)}.`)
+
+  let cert = yield cli.action(`Rolling back SSL certificate ${formattedEndpoint} for ${cli.color.app(context.app)}`, {}, heroku.request({
     path: `/apps/${context.app}/ssl-endpoints/${encodeURIComponent(endpoint.cname)}/rollback`,
     method: 'POST',
     headers: {'X-Heroku-API-Version': '2', 'Accept': 'application/json'}

--- a/commands/certs/rollback.js
+++ b/commands/certs/rollback.js
@@ -29,7 +29,8 @@ function * run (context, heroku) {
   certificateDetails(cert, 'New active certificate details:')
 }
 
-let cmd = {
+module.exports = {
+  topic: 'certs',
   command: 'rollback',
   flags: [
     {name: 'confirm', hasValue: true, optional: true, hidden: true},
@@ -41,9 +42,3 @@ let cmd = {
   needsAuth: true,
   run: cli.command(co.wrap(run))
 }
-
-module.exports = [
-  Object.assign({topic: 'certs'}, cmd),
-  Object.assign({topic: '_certs', hidden: true}, cmd)
-]
-

--- a/commands/certs/update.js
+++ b/commands/certs/update.js
@@ -7,6 +7,7 @@ let flags = require('../../lib/flags.js')
 let readFile = require('../../lib/read_file.js')
 let sslDoctor = require('../../lib/ssl_doctor.js')
 let displayWarnings = require('../../lib/display_warnings.js')
+let formatEndpoint = require('../../lib/format_endpoint.js')
 let certificateDetails = require('../../lib/certificate_details.js')
 
 function * run (context, heroku) {
@@ -27,11 +28,11 @@ function * run (context, heroku) {
     key = res.key
   }
 
-  yield cli.confirmApp(context.app, context.flags.confirm, `Potentially Destructive Action\nThis command will change the certificate of endpoint ${endpoint.name} (${endpoint.cname}) from ${cli.color.app(context.app)}.`)
+  let formattedEndpoint = formatEndpoint(endpoint)
 
-  let cname = endpoint.cname ? `(${endpoint.cname}) ` : ''
+  yield cli.confirmApp(context.app, context.flags.confirm, `Potentially Destructive Action\nThis command will change the certificate of endpoint ${formattedEndpoint} from ${cli.color.app(context.app)}.`)
 
-  let cert = yield cli.action(`Updating SSL certificate ${endpoint.name} ${cname}for ${cli.color.app(context.app)}`, {}, heroku.request({
+  let cert = yield cli.action(`Updating SSL certificate ${formattedEndpoint} for ${cli.color.app(context.app)}`, {}, heroku.request({
     path: endpoint._meta.path,
     method: 'PATCH',
     headers: {'Accept': `application/vnd.heroku+json; version=3.${endpoint._meta.variant}`},

--- a/commands/certs/update.js
+++ b/commands/certs/update.js
@@ -43,7 +43,8 @@ function * run (context, heroku) {
   displayWarnings(cert)
 }
 
-let cmd = {
+module.exports = {
+  topic: 'certs',
   command: 'update',
   args: [
     {name: 'CRT', optional: false},
@@ -64,8 +65,3 @@ let cmd = {
   needsAuth: true,
   run: cli.command(co.wrap(run))
 }
-
-module.exports = [
-  Object.assign({topic: 'certs'}, cmd),
-  Object.assign({topic: '_certs', hidden: true}, cmd)
-]

--- a/index.js
+++ b/index.js
@@ -8,7 +8,7 @@ exports.topic = {
   description: 'a topic for the ssl plugin'
 }
 
-exports.commands = _.flatten([
+let commands = [
   require('./commands/certs/index.js'),
   require('./commands/certs/add.js'),
   require('./commands/certs/chain.js'),
@@ -18,4 +18,17 @@ exports.commands = _.flatten([
   require('./commands/certs/remove.js'),
   require('./commands/certs/rollback.js'),
   require('./commands/certs/update.js')
-])
+]
+
+function deprecate (cmd) {
+  let deprecatedRun = function (context) {
+    let cli = require('heroku-cli-util')
+    let topicAndCommand = _.select([cmd.topic, cmd.command]).join(':')
+    cli.warn(`${cli.color.cmd(`heroku _${topicAndCommand}`)} has been deprecated. Please use ${cli.color.cmd(`heroku ${topicAndCommand}`)} instead.`)
+    return cmd.run(context)
+  }
+
+  return Object.assign({}, cmd, {topic: '_certs', hidden: true, run: deprecatedRun})
+}
+
+exports.commands = commands.concat(commands.map((cmd) => deprecate(cmd)))

--- a/lib/format_endpoint.js
+++ b/lib/format_endpoint.js
@@ -1,0 +1,9 @@
+'use strict'
+
+module.exports = function (endpoint) {
+  let display = endpoint.name
+  if (endpoint.cname) {
+    display += ` (${endpoint.cname})`
+  }
+  return display
+}

--- a/test/commands/certs/add.js
+++ b/test/commands/certs/add.js
@@ -53,7 +53,7 @@ describe('heroku certs:add', function () {
     error.exit.mock()
 
     inquirer = {}
-    certs = proxyquire('../../../commands/certs/add', {inquirer})[0]
+    certs = proxyquire('../../../commands/certs/add', {inquirer})
   })
 
   describe('(ported)', function () {

--- a/test/commands/certs/chain.js
+++ b/test/commands/certs/chain.js
@@ -6,7 +6,7 @@ let nock = require('nock')
 var fs = require('fs')
 var sinon = require('sinon')
 
-let certs = require('../../../commands/certs/chain.js')[0]
+let certs = require('../../../commands/certs/chain.js')
 let assertExit = require('../../assert_exit.js')
 let error = require('../../../lib/error.js')
 

--- a/test/commands/certs/generate.js
+++ b/test/commands/certs/generate.js
@@ -12,7 +12,7 @@ chai.use(sinonChai)
 let cli = require('heroku-cli-util')
 let childProcess = require('child_process')
 
-let certs = require('../../../commands/certs/generate.js')[0]
+let certs = require('../../../commands/certs/generate.js')
 let endpoint = require('../../stubs/sni-endpoints.js').endpoint
 
 let EventEmitter = require('events').EventEmitter

--- a/test/commands/certs/index.js
+++ b/test/commands/certs/index.js
@@ -3,7 +3,7 @@
 
 let expect = require('chai').expect
 let nock = require('nock')
-let certs = require('../../../commands/certs/index.js')[0]
+let certs = require('../../../commands/certs/index.js')
 
 let endpoint = require('../../stubs/sni-endpoints.js').endpoint
 let endpoint2 = require('../../stubs/sni-endpoints.js').endpoint2

--- a/test/commands/certs/info.js
+++ b/test/commands/certs/info.js
@@ -1,7 +1,7 @@
 'use strict'
 /* globals describe it beforeEach cli */
 
-let certs = require('../../../commands/certs/info.js')[0]
+let certs = require('../../../commands/certs/info.js')
 let nock = require('nock')
 let expect = require('chai').expect
 

--- a/test/commands/certs/key.js
+++ b/test/commands/certs/key.js
@@ -6,7 +6,7 @@ let nock = require('nock')
 var fs = require('fs')
 var sinon = require('sinon')
 
-let certs = require('../../../commands/certs/key.js')[0]
+let certs = require('../../../commands/certs/key.js')
 let assertExit = require('../../assert_exit.js')
 let error = require('../../../lib/error.js')
 

--- a/test/commands/certs/remove.js
+++ b/test/commands/certs/remove.js
@@ -3,7 +3,7 @@
 
 let expect = require('chai').expect
 let nock = require('nock')
-let certs = require('../../../commands/certs/remove.js')[0]
+let certs = require('../../../commands/certs/remove.js')
 let error = require('../../../lib/error.js')
 
 let endpoint = require('../../stubs/sni-endpoints.js').endpoint

--- a/test/commands/certs/rollback.js
+++ b/test/commands/certs/rollback.js
@@ -3,7 +3,7 @@
 
 let expect = require('chai').expect
 let nock = require('nock')
-let certs = require('../../../commands/certs/rollback.js')[0]
+let certs = require('../../../commands/certs/rollback.js')
 let error = require('../../../lib/error.js')
 let assertExit = require('../../assert_exit.js')
 

--- a/test/commands/certs/update.js
+++ b/test/commands/certs/update.js
@@ -6,7 +6,7 @@ let nock = require('nock')
 var fs = require('fs')
 var sinon = require('sinon')
 
-let certs = require('../../../commands/certs/update.js')[0]
+let certs = require('../../../commands/certs/update.js')
 let error = require('../../../lib/error.js')
 let shared = require('./shared.js')
 let sharedSsl = require('./shared_ssl.js')


### PR DESCRIPTION
@brettgoulder Could you review?  I found one spot where we were printing out `endpoint.cname` without checking existence first, so I encapsulated all the endpoint formatting to fix it.  I also added deprecation warnings to all `_certs` commands.
