### PR TITLE
Fix bug in ca_signed / self signed logic

### DIFF
--- a/lib/certificate_details.js
+++ b/lib/certificate_details.js
@@ -16,7 +16,7 @@ module.exports = function (cert, message) {
 
   if (cert.ssl_cert['ca_signed?']) {
     cli.log('SSL certificate is verified by a root authority.')
-  } else if (cert.issuer === cert.subject) {
+  } else if (cert.ssl_cert.issuer === cert.ssl_cert.subject) {
     cli.log('SSL certificate is self signed.')
   } else {
     cli.log('SSL certificate is not trusted.')

--- a/test/commands/certs/add.js
+++ b/test/commands/certs/add.js
@@ -723,7 +723,7 @@ Expires At:     2013-08-01 21:34 UTC
 Issuer:         /C=US/ST=California/L=San Francisco/O=Heroku by Salesforce/CN=heroku.com
 Starts At:      2012-08-01 21:34 UTC
 Subject:        /C=US/ST=California/L=San Francisco/O=Heroku by Salesforce/CN=tokyo-1050.herokuapp.com
-SSL certificate is self signed.
+SSL certificate is not trusted.
 
 === The following common names are for hosts that are managed by Heroku
 tokyo-1050.herokuapp.com

--- a/test/commands/certs/info.js
+++ b/test/commands/certs/info.js
@@ -9,6 +9,8 @@ let shared = require('./shared.js')
 let sharedSni = require('./shared_sni.js')
 let sharedSsl = require('./shared_ssl.js')
 let endpoint = require('../../stubs/sni-endpoints.js').endpoint
+let endpointUntrusted = require('../../stubs/sni-endpoints.js').endpoint_untrusted
+let endpointTrusted = require('../../stubs/sni-endpoints.js').endpoint_trusted
 let certificateDetails = require('../../stubs/sni-endpoints.js').certificate_details
 
 describe('heroku certs:info ported', function () {
@@ -38,6 +40,68 @@ describe('heroku certs:info ported', function () {
       expect(cli.stderr).to.equal('Fetching SSL certificate tokyo-1050 info for example... done\n')
       expect(cli.stdout).to.equal(`Certificate details:
 ${certificateDetails}
+`)
+    })
+  })
+
+  it('shows certificate details when not trusted', function () {
+    let mockSsl = nock('https://api.heroku.com')
+      .get('/apps/example/ssl-endpoints')
+      .reply(200, [endpoint])
+
+    let mockSni = nock('https://api.heroku.com')
+      .get('/apps/example/sni-endpoints')
+      .reply(200, [])
+
+    let mock = nock('https://api.heroku.com', {
+      reqheaders: {'Accept': 'application/vnd.heroku+json; version=3.ssl_cert'}
+    })
+      .get('/apps/example/ssl-endpoints/tokyo-1050')
+      .reply(200, endpointUntrusted)
+
+    return certs.run({app: 'example', args: {}, flags: {}}).then(function () {
+      mockSsl.done()
+      mockSni.done()
+      mock.done()
+      expect(cli.stderr).to.equal('Fetching SSL certificate tokyo-1050 info for example... done\n')
+      expect(cli.stdout).to.equal(`Certificate details:
+Common Name(s): example.org
+Expires At:     2013-08-01 21:34 UTC
+Issuer:         /C=US/ST=California/L=San Francisco/O=Heroku by Salesforce/CN=secure.example.org
+Starts At:      2012-08-01 21:34 UTC
+Subject:        /C=US/ST=California/L=San Francisco/O=Untrusted/CN=untrusted.example.org
+SSL certificate is not trusted.
+`)
+    })
+  })
+
+  it('shows certificate details when trusted', function () {
+    let mockSsl = nock('https://api.heroku.com')
+      .get('/apps/example/ssl-endpoints')
+      .reply(200, [endpoint])
+
+    let mockSni = nock('https://api.heroku.com')
+      .get('/apps/example/sni-endpoints')
+      .reply(200, [])
+
+    let mock = nock('https://api.heroku.com', {
+      reqheaders: {'Accept': 'application/vnd.heroku+json; version=3.ssl_cert'}
+    })
+      .get('/apps/example/ssl-endpoints/tokyo-1050')
+      .reply(200, endpointTrusted)
+
+    return certs.run({app: 'example', args: {}, flags: {}}).then(function () {
+      mockSsl.done()
+      mockSni.done()
+      mock.done()
+      expect(cli.stderr).to.equal('Fetching SSL certificate tokyo-1050 info for example... done\n')
+      expect(cli.stdout).to.equal(`Certificate details:
+Common Name(s): example.org
+Expires At:     2013-08-01 21:34 UTC
+Issuer:         /C=US/ST=California/L=San Francisco/O=Heroku by Salesforce/CN=secure.example.org
+Starts At:      2012-08-01 21:34 UTC
+Subject:        /C=US/ST=California/L=San Francisco/O=Trusted/CN=trusted.example.org
+SSL certificate is verified by a root authority.
 `)
     })
   })

--- a/test/stubs/sni-endpoints.js
+++ b/test/stubs/sni-endpoints.js
@@ -18,6 +18,28 @@ SSL certificate is self signed.`,
       'subject': '/C=US/ST=California/L=San Francisco/O=Heroku by Salesforce/CN=secure.example.org'
     }
   },
+  endpoint_untrusted: { 'name': 'tokyo-1050',
+    'cname': 'tokyo-1050.herokussl.com',
+    'ssl_cert': {
+      'ca_signed?': false,
+      'cert_domains': [ 'example.org' ],
+      'starts_at': '2012-08-01T21:34:23Z',
+      'expires_at': '2013-08-01T21:34:23Z',
+      'issuer': '/C=US/ST=California/L=San Francisco/O=Heroku by Salesforce/CN=secure.example.org',
+      'subject': '/C=US/ST=California/L=San Francisco/O=Untrusted/CN=untrusted.example.org'
+    }
+  },
+  endpoint_trusted: { 'name': 'tokyo-1050',
+    'cname': 'tokyo-1050.herokussl.com',
+    'ssl_cert': {
+      'ca_signed?': true,
+      'cert_domains': [ 'example.org' ],
+      'starts_at': '2012-08-01T21:34:23Z',
+      'expires_at': '2013-08-01T21:34:23Z',
+      'issuer': '/C=US/ST=California/L=San Francisco/O=Heroku by Salesforce/CN=secure.example.org',
+      'subject': '/C=US/ST=California/L=San Francisco/O=Trusted/CN=trusted.example.org'
+    }
+  },
   endpoint_heroku: { 'name': 'tokyo-1050',
     'cname': null,
     'ssl_cert': {


### PR DESCRIPTION
@dickeyxxx could you review?  when I was working on a new feature I noticed that we do not properly detect self signed certificates in `certs:info`