### PR TITLE
Fix regression with ssl doctor and intermediaries

### DIFF
--- a/lib/get_cert_and_key.js
+++ b/lib/get_cert_and_key.js
@@ -1,0 +1,34 @@
+'use strict'
+
+let readFile = require('./read_file.js')
+let error = require('./error.js')
+let sslDoctor = require('./ssl_doctor.js')
+
+function usageError () {
+  error.exit(1, 'Usage: heroku certs:add CRT KEY')
+}
+
+function * getFiles (context) {
+  return yield context.args.map((arg) => readFile(arg, 'utf-8'))
+}
+
+function * getFilesBypass (context) {
+  if (context.args.length > 2) usageError()
+  let files = yield getFiles(context)
+  return {crt: files[0], key: files[1]}
+}
+
+function * getFilesDoctor (context) {
+  let files = yield getFiles(context)
+  let res = JSON.parse(yield sslDoctor('resolve-chain-and-key', files))
+  return {crt: res.pem, key: res.key}
+}
+
+module.exports = function * (context) {
+  if (context.args.length < 2) usageError()
+  if (context.flags.bypass) {
+    return yield getFilesBypass(context)
+  } else {
+    return yield getFilesDoctor(context)
+  }
+}

--- a/test/commands/certs/update.js
+++ b/test/commands/certs/update.js
@@ -8,10 +8,12 @@ var sinon = require('sinon')
 
 let certs = require('../../../commands/certs/update.js')
 let error = require('../../../lib/error.js')
+let assertExit = require('../../assert_exit.js')
 let shared = require('./shared.js')
 let sharedSsl = require('./shared_ssl.js')
 let sharedSni = require('./shared_sni.js')
 
+let endpoint = require('../../stubs/sni-endpoints.js').endpoint
 let endpointStable = require('../../stubs/sni-endpoints.js').endpoint_stable
 let endpointWarning = require('../../stubs/sni-endpoints.js').endpoint_warning
 let certificateDetails = require('../../stubs/sni-endpoints.js').certificate_details
@@ -48,7 +50,7 @@ describe('heroku certs:update', function () {
     mockFile(fs, 'key_file', 'key content')
 
     var thrown = false
-    return certs.run({app: 'example', args: {CRT: 'pem_file', KEY: 'key_file'}, flags: {confirm: 'notexample', bypass: true}}).catch(function (err) {
+    return certs.run({app: 'example', args: ['pem_file', 'key_file'], flags: {confirm: 'notexample', bypass: true}}).catch(function (err) {
       thrown = true
       expect(err).to.equal('Confirmation notexample did not match example. Aborted.')
     }).then(function () {
@@ -75,7 +77,7 @@ describe('heroku certs:update', function () {
       })
       .reply(200, endpointStable)
 
-    return certs.run({app: 'example', args: {CRT: 'pem_file', KEY: 'key_file'}, flags: {name: 'tokyo-1050', confirm: 'example'}}).then(function () {
+    return certs.run({app: 'example', args: ['pem_file', 'key_file'], flags: {name: 'tokyo-1050', confirm: 'example'}}).then(function () {
       sslDoctor.done()
       mock.done()
       expect(cli.stderr).to.equal('Resolving trust chain... done\nUpdating SSL certificate tokyo-1050 for example... done\n')
@@ -83,6 +85,49 @@ describe('heroku certs:update', function () {
         `Updated certificate details:
 ${certificateDetails}
 `)
+    })
+  })
+
+  it('# posts intermediaries to ssl doctor', function () {
+    mockFile(fs, 'pem_file', 'pem content')
+    mockFile(fs, 'int_file', 'int content')
+    mockFile(fs, 'key_file', 'key content')
+
+    let sslDoctor = nock('https://ssl-doctor.heroku.com', {
+      reqheaders: {
+        'content-type': 'application/octet-stream',
+        'content-length': '35'
+      }
+    })
+      .post('/resolve-chain-and-key', 'pem content\nint content\nkey content')
+      .reply(200, {pem: 'pem content\nint content', key: 'key content'})
+
+    let mock = nock('https://api.heroku.com')
+      .patch('/apps/example/sni-endpoints/tokyo-1050', {
+        certificate_chain: 'pem content\nint content', private_key: 'key content'
+      })
+      .reply(200, endpoint)
+
+    return certs.run({app: 'example', args: ['pem_file', 'int_file', 'key_file'], flags: {confirm: 'example'}}).then(function () {
+      sslDoctor.done()
+      mock.done()
+      expect(cli.stderr).to.equal('Resolving trust chain... done\nUpdating SSL certificate tokyo-1050 for example... done\n')
+      expect(cli.stdout).to.equal(
+        `Updated certificate details:
+${certificateDetails}
+`)
+    })
+      /* eslint-enable no-irregular-whitespace */
+  })
+
+  it('# errors out when args < 2', function () {
+    nock('https://api.heroku.com')
+      .get('/apps/example')
+      .reply(200, { 'space': null })
+
+    return assertExit(1, certs.run({app: 'example', args: ['pem_file'], flags: {}})).then(function () {
+      expect(cli.stderr).to.equal(' ▸    Usage: heroku certs:add CRT KEY\n')
+      expect(cli.stdout).to.equal('')
     })
   })
 
@@ -99,7 +144,7 @@ ${certificateDetails}
       .post('/resolve-chain-and-key', 'pem content\nkey content')
       .reply(422, 'No certificate given is a domain name certificate.')
 
-    return certs.run({app: 'example', args: {CRT: 'pem_file', KEY: 'key_file'}, flags: {confirm: 'example'}})
+    return certs.run({app: 'example', args: ['pem_file', 'key_file'], flags: {confirm: 'example'}})
       .then(function () {
         expect.fail('Expected exception')
       })
@@ -121,13 +166,24 @@ ${certificateDetails}
       })
       .reply(200, endpointStable)
 
-    return certs.run({app: 'example', args: {name: 'tokyo-1050', CRT: 'pem_file', KEY: 'key_file'}, flags: {bypass: true, confirm: 'example'}}).then(function () {
+    return certs.run({app: 'example', args: ['pem_file', 'key_file'], flags: {bypass: true, confirm: 'example'}}).then(function () {
       mock.done()
       expect(cli.stderr).to.equal('Updating SSL certificate tokyo-1050 for example... done\n')
       expect(cli.stdout).to.equal(
         `Updated certificate details:
 ${certificateDetails}
 `)
+    })
+  })
+
+  it('# bypass errors out with intermediaries', function () {
+    nock('https://api.heroku.com')
+      .get('/apps/example')
+      .reply(200, { 'space': null })
+
+    return assertExit(1, certs.run({app: 'example', args: ['pem_file', 'int_file', 'key_file'], flags: {bypass: true}})).then(function () {
+      expect(cli.stderr).to.equal(' ▸    Usage: heroku certs:add CRT KEY\n')
+      expect(cli.stdout).to.equal('')
     })
   })
 
@@ -141,7 +197,7 @@ ${certificateDetails}
       })
       .reply(200, endpointWarning)
 
-    return certs.run({app: 'example', args: {name: 'tokyo-1050', CRT: 'pem_file', KEY: 'key_file'}, flags: {bypass: true, confirm: 'example'}}).then(function () {
+    return certs.run({app: 'example', args: ['pem_file', 'key_file'], flags: {bypass: true, confirm: 'example'}}).then(function () {
       mock.done()
       expect(unwrap(cli.stderr)).to.equal('Updating SSL certificate tokyo-1050 for example... done WARNING: ssl_cert provides no domain(s) that are configured for this Heroku app\n')
     })
@@ -175,15 +231,15 @@ ${certificateDetails}
     }
 
     shared.shouldHandleArgs('certs:update', 'updates an endpoint', certs, callback, {
-      stderr, stdout, args: {CRT: 'pem_file', KEY: 'key_file'}, flags: {bypass: true, confirm: 'example'}
+      stderr, stdout, args: ['pem_file', 'key_file'], flags: {bypass: true, confirm: 'example'}
     })
 
     sharedSsl.shouldHandleArgs('certs:update', 'updates an endpoint', certs, callback, {
-      stderr, stdout, args: {CRT: 'pem_file', KEY: 'key_file'}, flags: {bypass: true, confirm: 'example'}
+      stderr, stdout, args: ['pem_file', 'key_file'], flags: {bypass: true, confirm: 'example'}
     })
 
     sharedSni.shouldHandleArgs('certs:update', 'updates an endpoint', certs, callback, {
-      stderr, stdout, args: {CRT: 'pem_file', KEY: 'key_file'}, flags: {bypass: true, confirm: 'example'}
+      stderr, stdout, args: ['pem_file', 'key_file'], flags: {bypass: true, confirm: 'example'}
     })
   })
 })
@@ -226,7 +282,7 @@ describe('heroku certs:update (dogwood)', function () {
       })
       .reply(200, endpointStable)
 
-    return certs.run({app: 'example', args: {CRT: 'pem_file', KEY: 'key_file'}, flags: {name: 'tokyo-1050', confirm: 'example', bypass: true}}).then(function () {
+    return certs.run({app: 'example', args: ['pem_file', 'key_file'], flags: {name: 'tokyo-1050', confirm: 'example', bypass: true}}).then(function () {
       mockSni.done()
       mockPut.done()
       expect(cli.stderr).to.equal('Updating SSL certificate tokyo-1050 for example... done\n')


### PR DESCRIPTION
@dickeyxxx could you review?  This fixes a regression reported in https://github.com/heroku/heroku-certs/issues/31

This functionality was present in the ruby codebase, but I missed it when porting over to Javascript.  I maintained the constraint that `--bypass` does not work with intermediaries because I think ssl doctor does some munging when it encounters intermediary certificates that I think we need to preserve.

https://github.com/heroku/legacy-cli/blob/master/lib/heroku/command/certs.rb#L233-L240
https://github.com/heroku/legacy-cli/blob/master/lib/heroku/command/certs.rb#L257-L262