### PR TITLE
Return "In Progress" for "dns-verified" from API

### DIFF
--- a/commands/certs/auto.js
+++ b/commands/certs/auto.js
@@ -12,12 +12,8 @@ function humanize (value) {
   if (value === 'ok') {
     return 'OK'
   }
-  // Remove the following lines once we address this in cedar-acm
-  if (value === 'verified') {
-    return 'In Progress'
-  }
   if (value === 'dns-verified') {
-    return 'DNS Verified'
+    return 'In Progress'
   }
   return value.split('-').map((word) => _.capitalize(word)).join(' ')
 }

--- a/test/commands/certs/auto.js
+++ b/test/commands/certs/auto.js
@@ -81,8 +81,6 @@ heroku-san-test.heroku-cli-sni-test.com  OK
       {'kind': 'heroku', 'hostname': 'tokyo-1050.herokuapp.com', 'cname': null, 'acm_status': null},
       {'kind': 'custom', 'hostname': 'heroku-acm.heroku-cli-sni-test.com', 'cname': 'heroku-acm.heroku-cli-sni-test.com.herokudns.com', 'acm_status': 'ok'},
       {'kind': 'custom', 'hostname': 'heroku-san-test.heroku-cli-sni-test.com', 'cname': 'heroku-san-test.heroku-cli-sni-test.com.herokudns.com', 'acm_status': 'ok'},
-      {'kind': 'custom', 'hostname': 'heroku-in-prog.heroku-cli-sni-test.com', 'cname': 'heroku-in-prog.heroku-cli-sni-test.com.herokudns.com', 'acm_status': 'in-progress'},
-      {'kind': 'custom', 'hostname': 'heroku-verified.heroku-cli-sni-test.com', 'cname': 'heroku-verified.heroku-cli-sni-test.com.herokudns.com', 'acm_status': 'verified'},
       {'kind': 'custom', 'hostname': 'heroku-dns-verified.heroku-cli-sni-test.com', 'cname': 'heroku-dns-verified.heroku-cli-sni-test.com.herokudns.com', 'acm_status': 'dns-verified'},
       {'kind': 'custom', 'hostname': 'heroku-missing.heroku-cli-sni-test.com', 'cname': 'heroku-missing.heroku-cli-sni-test.com.herokudns.com', 'acm_status': 'failing'},
       {'kind': 'custom', 'hostname': 'heroku-unknown.heroku-cli-sni-test.com', 'cname': 'heroku-unknown.heroku-cli-sni-test.com.herokudns.com', 'acm_status': null}
@@ -103,12 +101,10 @@ Subject:        /CN=heroku-acm.heroku-cli-sni-test.com
 SSL certificate is not trusted.
 
 Domain                                       Status
-───────────────────────────────────────────  ────────────
+───────────────────────────────────────────  ───────────
 heroku-acm.heroku-cli-sni-test.com           OK
 heroku-san-test.heroku-cli-sni-test.com      OK
-heroku-in-prog.heroku-cli-sni-test.com       In Progress
-heroku-verified.heroku-cli-sni-test.com      In Progress
-heroku-dns-verified.heroku-cli-sni-test.com  DNS Verified
+heroku-dns-verified.heroku-cli-sni-test.com  In Progress
 heroku-missing.heroku-cli-sni-test.com       Failing
 heroku-unknown.heroku-cli-sni-test.com       Waiting
 


### PR DESCRIPTION
According to @ypaq, "verified" is no longer returned from the API.  "In Progress" was added by @brettgoulder, but then overridden by @ransombriggs, creating user confusion.  

This PR hopes to remove that confusion and align with our docs.