### PR TITLE
Add devcenter docs when failing

### DIFF
--- a/commands/certs/auto.js
+++ b/commands/certs/auto.js
@@ -83,8 +83,10 @@ function * run (context, heroku) {
       message = `Add a custom domain to your app by running: ${cli.color.cmd('heroku domains:add <yourdomain.com>')}`
     } else if (_.some(domains, (domain) => domain.acm_status === 'failed')) {
       message = `Some domains failed validation after multiple attempts, retry by running: ${cli.color.cmd('heroku certs:auto:refresh')}`
+      message += `\n    See our documentation at https://devcenter.heroku.com/articles/automated-certificate-management#failure-reasons`
     } else if (_.some(domains, (domain) => domain.acm_status === 'failing')) {
       message = `Some domains are failing validation, please verify that your DNS matches: ${cli.color.cmd('heroku domains')}`
+      message += `\n    See our documentation at https://devcenter.heroku.com/articles/automated-certificate-management#failure-reasons`
     }
 
     if (message) {

--- a/test/commands/certs/auto.js
+++ b/test/commands/certs/auto.js
@@ -115,6 +115,7 @@ heroku-missing.heroku-cli-sni-test.com       Failing       less than a minute
 heroku-unknown.heroku-cli-sni-test.com       Waiting       less than a minute
 
 === Some domains are failing validation, please verify that your DNS matches: heroku domains
+    See our documentation at https://devcenter.heroku.com/articles/automated-certificate-management#failure-reasons
 `)
       api.done()
       apiCerts.done()
@@ -157,6 +158,7 @@ heroku-missing.heroku-cli-sni-test.com   Failing  less than a minute
 heroku-unknown.heroku-cli-sni-test.com   Waiting  less than a minute
 
 === Some domains are failing validation, please verify that your DNS matches: heroku domains
+    See our documentation at https://devcenter.heroku.com/articles/automated-certificate-management#failure-reasons
 `)
       api.done()
       apiCerts.done()
@@ -201,6 +203,7 @@ heroku-san-test.heroku-cli-sni-test.com  OK      less than a minute
 heroku-failed.heroku-cli-sni-test.com    Failed  less than a minute
 
 === Some domains failed validation after multiple attempts, retry by running: heroku certs:auto:refresh
+    See our documentation at https://devcenter.heroku.com/articles/automated-certificate-management#failure-reasons
 `)
       api.done()
       apiCerts.done()
@@ -244,6 +247,7 @@ heroku-san-test.heroku-cli-sni-test.com  OK       less than a minute
 heroku-failed.heroku-cli-sni-test.com    Failing  less than a minute
 
 === Some domains are failing validation, please verify that your DNS matches: heroku domains
+    See our documentation at https://devcenter.heroku.com/articles/automated-certificate-management#failure-reasons
 `)
       api.done()
       apiCerts.done()
@@ -296,6 +300,7 @@ heroku-acm.heroku-cli-sni-test.com      OK       less than a minute
 heroku-failing.heroku-cli-sni-test.com  Failing  less than a minute
 
 === Some domains are failing validation, please verify that your DNS matches: heroku domains
+    See our documentation at https://devcenter.heroku.com/articles/automated-certificate-management#failure-reasons
 `)
       api.done()
       apiCerts.done()
@@ -423,6 +428,7 @@ heroku-acm.heroku-cli-sni-test.com     OK                              less than
 heroku-failed.heroku-cli-sni-test.com  Failed  uh oh something failed  less than a minute
 
 === Some domains failed validation after multiple attempts, retry by running: heroku certs:auto:refresh
+    See our documentation at https://devcenter.heroku.com/articles/automated-certificate-management#failure-reasons
 `)
       api.done()
       apiCerts.done()


### PR DESCRIPTION
We still send this link in the email, but that email arrives when the retries are exhausted (after 1 hour). In some cases, providing these helpful links during the debugging phase would be really helpful.
